### PR TITLE
Fix another variant of #36

### DIFF
--- a/DysonFanState.js
+++ b/DysonFanState.js
@@ -47,8 +47,8 @@ class DysonFanState {
         //     this._fanState = 1;
         // }
         // With TP04 models average cflr and hflr
-        let filterReading = newState["product-state"]["filf"] ||
-            (newState["product-state"]["cflr"] + newState["product-state"]["hflr"])/2;
+        let filterReading = this.getFieldValue(newState, "filf") ||
+            (this.getFieldValue(newState, "cflr") + this.getFieldValue(newState, "hflr"))/2;
         // Assuming the max life is 12 * 365 = 4380 hrs
         this._filterLife = Number.parseInt(filterReading) * 100 / 4380;
         // Set to chang the filter when the life is below 10%


### PR DESCRIPTION
I was getting an error very similar to #36 with my Dyson Pure Cool:

```
[7/15/2018, 10:19:15 PM] [DysonPlatform] {"msg":"CURRENT-STATE","time":"2018-07-15T21:19:13.000Z","mode-reason":"state-reason","MODE":"dial","OFF":"product-state","fmod":"FAN","fnst":"FAN","fnsp":"0010","qtar":"0003","oson":"OFF","rh
[7/15/2018, 10:19:15 PM] [DysonPlatform] Update fan data from CURRENT-STATE - Dyson Cool
/usr/lib/node_modules/homebridge-dyson-link/DysonFanState.js:50
        let filterReading = newState["product-state"]["filf"] ||
                                                     ^
TypeError: Cannot read property 'filf' of undefined
    at DysonFanState.updateState (/usr/lib/node_modules/homebridge-dyson-link/DysonFanState.js:50:54)
    at MqttClient.DysonLinkDevice.mqttClient.on (/usr/lib/node_modules/homebridge-dyson-link/DysonLinkDevice.js:74:39)
    at emitThree (events.js:116:13)
    at MqttClient.emit (events.js:194:7)
    at MqttClient._handlePublish (/usr/lib/node_modules/homebridge-dyson-link/node_modules/mqtt/lib/client.js:940:12)
    at MqttClient._handlePacket (/usr/lib/node_modules/homebridge-dyson-link/node_modules/mqtt/lib/client.js:305:12)
    at work (/usr/lib/node_modules/homebridge-dyson-link/node_modules/mqtt/lib/client.js:261:12)
    at Writable.writable._write (/usr/lib/node_modules/homebridge-dyson-link/node_modules/mqtt/lib/client.js:271:5)
    at doWrite (/usr/lib/node_modules/homebridge-dyson-link/node_modules/readable-stream/lib/_stream_writable.js:428:64)
    at writeOrBuffer (/usr/lib/node_modules/homebridge-dyson-link/node_modules/readable-stream/lib/_stream_writable.js:417:5)
```

The filter life handling didn't use getFieldValue. That fixed it.