### PR TITLE
Several enhancements to fan speed steps, device information, auto mode and air quality algorithm

### DIFF
--- a/DysonEnvironmentState.js
+++ b/DysonEnvironmentState.js
@@ -5,19 +5,33 @@ class DysonEnvironmentState {
         this._lastUpdated = new Date(newState.time);
 
         // Gets all possible values from the data (depending on the model)
-        let pm25 = this.getCharacteristicValue(newState.data.pm25);
-        let pm10 = this.getCharacteristicValue(newState.data.pm10);
-        let voc = this.getCharacteristicValue(newState.data.va10);
-        let no2 = this.getCharacteristicValue(newState.data.noxl);
+        this._pm2_5Density = this.getNumericValue(newState.data.p25r);
+        this._pm10Density = this.getNumericValue(newState.data.p10r);
+        this._vocDensity = this.getNumericValue(newState.data.va10);
+        this._nitrogenDioxideDensity = this.getNumericValue(newState.data.noxl);
         let p = this.getCharacteristicValue(newState.data.pact);
         let v = this.getCharacteristicValue(newState.data.vact);
 
         // Gets the highest value, which means the one with the baddest results
-        this._airQuality = Math.max(pm25, pm10, voc, no2, p, v);
+        this._airQuality = Math.max(
+            this.getCharacteristicValue(newState.data.pm25), 
+            this.getCharacteristicValue(newState.data.pm10),
+            this.getCharacteristicValue(newState.data.va10),
+            this.getCharacteristicValue(newState.data.noxl),
+            p, v);
         
         this._humidity = Number.parseInt(newState.data.hact);
         // Reference: http://aakira.hatenablog.com/entry/2016/08/12/012654
         this._temperature = Number.parseFloat(newState.data.tact) / 10 - 273;
+    }
+
+    getNumericValue(rawValue) {
+
+        // Converts the raw value into an integer
+        if (!rawValue) {
+            return 0;
+        }
+        return Number.parseInt(rawValue);
     }
 
     getCharacteristicValue(rawValue) {
@@ -46,6 +60,10 @@ class DysonEnvironmentState {
 
     get lastUpdated() {return this._lastUpdated;}
     get airQuality() {return this._airQuality;}
+    get pm2_5Density() {return this._pm2_5Density;}
+    get pm10Density() {return this._pm10Density;}
+    get vocDensity() {return this._vocDensity;}
+    get nitrogenDioxideDensity() {return this._nitrogenDioxideDensity;}
     get humidity() {return this._humidity;}
     get temperature() {return this._temperature;}
 

--- a/DysonLinkAccessory.js
+++ b/DysonLinkAccessory.js
@@ -59,6 +59,17 @@ class DysonLinkAccessory {
             .on("get", this.device.getAirQuality.bind(this.device));
 
 
+        if (this.device.model == "438" || this.device.model == "520") {
+            this.airSensor.getCharacteristic(Characteristic.PM2_5Density)
+                .on("get", this.device.getPM2_5Density.bind(this.device));
+            this.airSensor.getCharacteristic(Characteristic.PM10Density)
+                .on("get", this.device.getPM10Density.bind(this.device));
+            this.airSensor.getCharacteristic(Characteristic.VOCDensity)
+                .on("get", this.device.getVOCDensity.bind(this.device));
+            this.airSensor.getCharacteristic(Characteristic.NitrogenDioxideDensity)
+                .on("get", this.device.getNitrogenDioxideDensity.bind(this.device));
+        }
+
         // Updates the accessory information
         var accessoryInformationService = this.getService(Service.AccessoryInformation);
         accessoryInformationService.setCharacteristic(Characteristic.Manufacturer, "Dyson");

--- a/DysonLinkAccessory.js
+++ b/DysonLinkAccessory.js
@@ -12,7 +12,7 @@ function setHomebridge(homebridge) {
 }
 
 class DysonLinkAccessory {
-    constructor(displayName, device, accessory, log, nightModeVisible, focusModeVisible) {
+    constructor(displayName, device, accessory, log, nightModeVisible, focusModeVisible, autoModeVisible) {
 
 
         this.device = device;
@@ -24,6 +24,7 @@ class DysonLinkAccessory {
 
         this.nightModeVisible = nightModeVisible;
         this.focusModeVisible = focusModeVisible;
+        this.autoModeVisible = autoModeVisible;
 
         this.initSensor();
         this.initFanState();
@@ -56,6 +57,17 @@ class DysonLinkAccessory {
         this.airSensor
             .getCharacteristic(Characteristic.AirQuality)
             .on("get", this.device.getAirQuality.bind(this.device));
+
+
+        // Updates the accessory information
+        var accessoryInformationService = this.getService(Service.AccessoryInformation);
+        accessoryInformationService.setCharacteristic(Characteristic.Manufacturer, "Dyson");
+        if (this.device.model == "438" || this.device.model == "520") {
+            accessoryInformationService.setCharacteristic(Characteristic.Model, "Dyson Pure Cool " + this.device.model);
+        } else {
+            accessoryInformationService.setCharacteristic(Characteristic.Model, "Dyson " + this.device.model);
+        }
+        accessoryInformationService.setCharacteristic(Characteristic.SerialNumber, this.device.serialNumber);
     }
 
     initFanState() {
@@ -97,6 +109,9 @@ class DysonLinkAccessory {
 
         // This is actually the fan speed instead of rotation speed but homekit fan does not support this
         this.fan.getCharacteristic(Characteristic.RotationSpeed)
+            .setProps({
+                minStep: 10
+            })
             .on("get", this.device.getFanSpeed.bind(this.device))
             .on("set", this.device.setFanSpeed.bind(this.device));        
 
@@ -196,12 +211,13 @@ class DysonLinkAccessory {
                 this.fan.removeCharacteristic(targetFanCharacteristic);
             }
 
-            this.autoSwitch = this.getServiceBySubtype(Service.Switch, "Auto - " + this.displayName, "Auto");
-            
-            this.autoSwitch
-                .getCharacteristic(Characteristic.On)
-                .on("get", this.device.isFanAuto.bind(this.device))
-                .on("set", this.device.setFanAuto.bind(this.device));
+            if (this.autoModeVisible) {
+                this.autoSwitch = this.getServiceBySubtype(Service.Switch, "Auto - " + this.displayName, "Auto");
+                this.autoSwitch
+                    .getCharacteristic(Characteristic.On)
+                    .on("get", this.device.isFanAuto.bind(this.device))
+                    .on("set", this.device.setFanAuto.bind(this.device));
+            }
             
         }
 

--- a/DysonLinkDevice.js
+++ b/DysonLinkDevice.js
@@ -310,33 +310,33 @@ class DysonLinkDevice {
     }
 
     setFanOn(value, callback) {
-        this.log.error("CHECK VALUE" + value);
         // Do not set the fmod to FAN if the fan is set to AUTO already
-        if(!this.fanState.fanAuto || value!= 1){
-            this.isFanOn(function(isOn) {
+        if(!this.fanState.fanAuto || value != 1){
 
-            });
-            if (this.Is2018Dyson) {
-                this.setState({fpwr: value==1 ? "ON" : "OFF"})
-            }
-            else {
-                this.setState({fmod: value == 1 ? "FAN" : "OFF"});
-            }
-            // Try to set the fan status according to the value in the home app
-            if(value ==1) {
-                if(this.accessory.getFanSpeedValue() >0 && !this.fanState.fanAuto) {
-                    this.log.info(this.displayName + " Try to restore the fan speed state from home app to " + this.accessory.getFanSpeedValue());
-                    this.setState({ fnsp: Math.round(this.accessory.getFanSpeedValue() / 10).toString() });
+            // Checks if the fan is already in the requested state (HomeKit wants to set the Active characteristic every time the rotation speed changes)
+            if (value != 1 || (value == 1 && !this.fanState.fanOn)) {
+                if (this.Is2018Dyson) {
+                    this.setState({fpwr: value==1 ? "ON" : "OFF"})
                 }
-                if(this.accessory.isSwingModeButtonOn()) {
-                    this.log.info(this.displayName + " Try to restore the fan swing state from home app");
-                    this.setState({ oson: "ON" });
-                }
-                if(this.accessory.isNightModeSwitchOn()) {
-                    this.log.info(this.displayName + " Try to restore the night mode state from home app");
-                    this.setState({ nmod: "ON" });
+                else {
+                    this.setState({fmod: value == 1 ? "FAN" : "OFF"});
                 }
 
+                // Try to set the fan status according to the value in the home app
+                if(value ==1) {
+                    if(this.accessory.getFanSpeedValue() >0 && !this.fanState.fanAuto) {
+                        this.log.info(this.displayName + " Try to restore the fan speed state from home app to " + this.accessory.getFanSpeedValue());
+                        this.setState({ fnsp: Math.round(this.accessory.getFanSpeedValue() / 10).toString() });
+                    }
+                    if(this.accessory.isSwingModeButtonOn()) {
+                        this.log.info(this.displayName + " Try to restore the fan swing state from home app");
+                        this.setState({ oson: "ON" });
+                    }
+                    if(this.accessory.isNightModeSwitchOn()) {
+                        this.log.info(this.displayName + " Try to restore the night mode state from home app");
+                        this.setState({ nmod: "ON" });
+                    }
+                }
             }
         }
         this.isFanOn(callback);

--- a/DysonLinkDevice.js
+++ b/DysonLinkDevice.js
@@ -441,7 +441,27 @@ class DysonLinkDevice {
             this.log.info(this.displayName + "- air quality cached value: " + this.environment.airQuality);
             callback(null, this.environment.airQuality);
         }
+    }
 
+    getPM2_5Density(callback) {
+        this.getAirQuality(function() {
+            callback(null, this.environment.pm2_5Density);
+        }.bind(this));
+    }
+    getPM10Density(callback) {
+        this.getAirQuality(function() {
+            callback(null, this.environment.pm10Density);
+        }.bind(this));
+    }
+    getVOCDensity(callback) {
+        this.getAirQuality(function() {
+            callback(null, this.environment.vocDensity);
+        }.bind(this));
+    }
+    getNitrogenDioxideDensity(callback) {
+        this.getAirQuality(function() {
+            callback(null, this.environment.nitrogenDioxideDensity);
+        }.bind(this));
     }
 
     notUpdatedRecently() {

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ There are a few optional parameters for each accessory, E.g.
           "serialNumber": "XXX-XX-XXXXXXXX",
           // No device password needed if TP04 or DP04
 
-          // Air quality sensitivity - This is default to 1
-          "sensitivity" : 1,
-
           // This controls the visibility of Night Mode button, default to true
           "nightModeVisible" : true,
 
           // This controls the visibility of Jet Focus button, default to true
-          "focusModeVisible" : true
+          "focusModeVisible" : true,
+
+          // This controls the visibility of Auto button, default to true
+          "autoModeVisible" : true
 
         },
         {
@@ -99,9 +99,6 @@ There are a few optional parameters for each accessory, E.g.
           "serialNumber": "DYSON-XXX-XX-XXXXXXXX-XXX",
           "password": "password of your second device"
           // Password may be used with other models
-
-          // Air quality sensitivity - This is default to 1
-          "sensitivity" : 1,
 
           // This controls the visibility of Night Mode button, default to true
           "nightModeVisible" : true,

--- a/config-sample.json
+++ b/config-sample.json
@@ -20,8 +20,7 @@
           "ip": "ip of your second device",
           "displayName": "Name to be shown on Home App",
           "serialNumber": "DYSON-XXX-XX-XXXXXXXX-XXX",
-          "password": "password of your second device",
-          "sensitivity": 1 // the higher, the worse air quality level
+          "password": "password of your second device"
         }
         // If you have more than one device(s), just add the same config below
       ]

--- a/index.js
+++ b/index.js
@@ -47,11 +47,7 @@ class DysonPlatform {
                     let accountPassword = this.config.password || process.env.DYSON_PASSWORD;
                     let accountEmail = this.config.email || process.env.DYSON_EMAIL;
                     this.getDevicesFromAccount(accountEmail, accountPassword, config.country, (accountDevices) => {
-                        this.config.accessories.forEach((accessory) => {                            
-                            let sensitivity = accessory.sensitivity;
-                            if (!sensitivity) {
-                                sensitivity = 1.0;
-                            }
+                        this.config.accessories.forEach((accessory) => {
                             let nightModeVisible = accessory.nightModeVisible;
                             if(nightModeVisible == null || nightModeVisible == undefined) {
                                 platform.log.debug("no night mode visible value, default to true");
@@ -61,6 +57,11 @@ class DysonPlatform {
                             if(focusModeVisible == null || focusModeVisible == undefined) {
                                 platform.log.debug("no focus mode visible value, default to true");
                                 focusModeVisible = true;
+                            }
+                            let autoModeVisible = accessory.autoModeVisible;
+                            if(autoModeVisible == null || autoModeVisible == undefined) {
+                                platform.log.debug("no auto mode visible value, default to true");
+                                autoModeVisible = true;
                             }
                             let deviceInfo = accountDevices[accessory.serialNumber];
                             var password = ''
@@ -72,8 +73,7 @@ class DysonPlatform {
                                 password = crypto.createHash('sha512').update(accessory.password, "utf8").digest("base64");
                             }
                             platform.log(accessory.displayName + " IP:" + accessory.ip + " Serial Number:" + accessory.serialNumber);
-                            let device = new DysonLinkDevice(accessory.displayName, accessory.ip, accessory.serialNumber, password, 
-                                platform.log, sensitivity);
+                            let device = new DysonLinkDevice(accessory.displayName, accessory.ip, accessory.serialNumber, password, platform.log);
                             if (device.valid) {
                                 platform.log("Device serial number format valids");
                                 let uuid = UUIDGen.generate(accessory.serialNumber);
@@ -82,13 +82,13 @@ class DysonPlatform {
                                 if (!cachedAccessory) {
                                     platform.log("Device not cached. Create a new one");
                                     let dysonAccessory = new Accessory(accessory.displayName, uuid);
-                                    new DysonLinkAccessory(accessory.displayName, device, dysonAccessory, platform.log, nightModeVisible, focusModeVisible);
+                                    new DysonLinkAccessory(accessory.displayName, device, dysonAccessory, platform.log, nightModeVisible, focusModeVisible, autoModeVisible);
                                     platform.api.registerPlatformAccessories("homebridge-dyson-link", "DysonPlatform", [dysonAccessory]);
                                     platform.accessories.push(accessory);
                                 } else {
                                     platform.log("Device cached. Try to update this");
                                     cachedAccessory.displayName = accessory.displayName;
-                                    new DysonLinkAccessory(accessory.displayName, device, cachedAccessory, platform.log, nightModeVisible, focusModeVisible);
+                                    new DysonLinkAccessory(accessory.displayName, device, cachedAccessory, platform.log, nightModeVisible, focusModeVisible, autoModeVisible);
                                     platform.api.updatePlatformAccessories([cachedAccessory]);
                                 }
                             }


### PR DESCRIPTION
As the Dyson devices only have 10 steps for fan speed, I forked your project and added the "minStep" property to the fans. Moreover, there are properties for the air quality sensor like PM2.5, PM10, VOC and NO2, which I also integrated (#43). I also added the device information to the accessories (#40) Finally, there seemed to be issues (#49) with setting the rotation speed (which is due to the fact, that the home app sets the "Active" characteristic to "On" every time you change the rotation speed), which is have solved.

I also took a quick look at the calculation for the air quality (#46) and tried to enhance the algorithm. I'm not using the "Auto" mode, so I added the property "autoModeVisible" to the configuration.

If you would like me to create a pull request (and you have time for a code review), feel free to ask me.
I own the latest Pure Cool tower and table fans, however, I don't have access to the older models to provide better support.