### PR TITLE
Reverse NightMode switch state in HomeKit

### DIFF
--- a/DysonFanState.js
+++ b/DysonFanState.js
@@ -26,7 +26,7 @@ class DysonFanState {
                     (this.getFieldValue(newState, "auto") === "ON" && this._fan);
  
         this._rotate = this.getFieldValue(newState, "oson") === "ON";
-        this._nightMode = this.getFieldValue(newState, "nmod") === "ON";        
+        this._nightMode = this.getFieldValue(newState, "nmod") === "ON" ? false : true;        
         this._speed = (Number.parseInt(this.getFieldValue(newState, "fnsp"))||5) * 10;
         if (this.heatAvailable) {
             this._heat = this.getFieldValue(newState, "hmod") === "HEAT";

--- a/DysonLinkAccessory.js
+++ b/DysonLinkAccessory.js
@@ -128,7 +128,7 @@ class DysonLinkAccessory {
 
         if(this.nightModeVisible) {
             this.log.info("Night mode button is added");
-            this.nightModeSwitch = this.getServiceBySubtype(Service.Switch, "Night Mode - " + this.displayName, "Night Mode");
+            this.nightModeSwitch = this.getServiceBySubtype(Service.Switch, "LED - " + this.displayName, "LED");//changed name to LED (and reversing the Night Mode switch to function as a normal light. Either the Fan LED Light is ON or OFF.
 
             this.nightModeSwitch
                 .getCharacteristic(Characteristic.On)

--- a/DysonLinkDevice.js
+++ b/DysonLinkDevice.js
@@ -236,13 +236,13 @@ class DysonLinkDevice {
     }
 
     setNightMode(value, callback) {
-        this.setState({ nmod: value ? "ON" : "OFF" });
+        this.setState({ nmod: value ? "OFF" : "ON" });
         this.isNightMode(callback);
     }
 
     isNightMode(callback) {
         this.mqttEvent.once(this.STATE_EVENT, () => {
-            this.log.info(this.displayName + " - Night Mode: " + this.fanState.nightMode);
+            this.log.info(this.displayName + " - Night Mode: " + this.fanState.nightMode);//this.fanState.nightMode has been reversed to function in HomeKit as an LED light on/off.
             callback(null, this.fanState.nightMode);
         });
         // Request for update


### PR DESCRIPTION
This is so NightMode switch behaves as an LED light in HomeKit.
DysonNightMode ON = HomeKit Fan LED light OFF

Its a far more logical approach for HomeKit. Siri Commands like "Turn of the lights" in a given room switch the Dyson nightMode to ON