### PR TITLE
Add an error message to help users debug incorrect serial number configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,8 +69,12 @@ class DysonPlatform {
                                 password = deviceInfo.password;
                                 accessory.serialNumber = 'DYSON-'+accessory.serialNumber+'-'+deviceInfo.ProductType;
                             }
-                            else {
+                            else if (accessory.password) {
                                 password = crypto.createHash('sha512').update(accessory.password, "utf8").digest("base64");
+                            }
+                            else {
+                                platform.log.error("Missing password for device with serial number " + accessory.serialNumber + ", devices found on your account: " + Object.keys(accountDevices).join(", "));
+                                return;
                             }
                             platform.log(accessory.displayName + " IP:" + accessory.ip + " Serial Number:" + accessory.serialNumber);
                             let device = new DysonLinkDevice(accessory.displayName, accessory.ip, accessory.serialNumber, password, platform.log);


### PR DESCRIPTION
Currently if you're relying on a password being fetched from your user account, but the serial number you've entered doesn't match anything on your account, the plugin will cause homebridge to crash and provide no information on what went wrong.

This PR prevents the crash and shows an error message with a list of serial numbers that are registered to your account, so the configuration can be easily corrected.