### PR TITLE
Support for Pure Hot + Cool 2018 (HP04)

### DIFF
--- a/DysonLinkAccessory.js
+++ b/DysonLinkAccessory.js
@@ -233,7 +233,7 @@ class DysonLinkAccessory {
         }
 
         // Add jet focus for Cool/Heat and 2018 Cool device
-        if(this.device.heatAvailable || this.device.is2018Dyson) {
+        if((this.device.heatAvailable && this.device.model !== '527') || this.device.is2018Dyson) {
             if(this.focusModeVisible) {
                 this.log.info("Jet Focus mode button is added");
                 this.focusSwitch = this.getServiceBySubtype(Service.Switch, "Jet Focus - " + this.displayName, "Jet Focus");

--- a/DysonLinkAccessory.js
+++ b/DysonLinkAccessory.js
@@ -167,11 +167,20 @@ class DysonLinkAccessory {
             this.heater.getCharacteristic(Characteristic.CurrentHeaterCoolerState)
                 .on("set", this.device.setCurrentHeaterCoolerState.bind(this.device))
                 .on("get", this.device.getCurrentHeaterCoolerState.bind(this.device));
-            
 
-            this.heater.getCharacteristic(Characteristic.TargetHeaterCoolerState)
-                .on("get", this.device.getHeaterCoolerState.bind(this.device))
-                .on("set", this.device.setHeaterCoolerState.bind(this.device));
+            if (this.device.model === '527') {
+                this.heater.getCharacteristic(Characteristic.TargetHeaterCoolerState)
+                    .on("get", this.device.getHeaterCoolerState.bind(this.device))
+                    .on("set", this.device.setHeaterCoolerState.bind(this.device))
+                    .setProps({
+                        // Disable COOL and AUTO, leave only HEAT
+                        validValues: [1],
+                    });
+            } else {
+                this.heater.getCharacteristic(Characteristic.TargetHeaterCoolerState)
+                    .on("get", this.device.getHeaterCoolerState.bind(this.device))
+                    .on("set", this.device.setHeaterCoolerState.bind(this.device));
+            }
 
             this.heater.getCharacteristic(Characteristic.CurrentTemperature)
                 .on("get", this.device.getTemperture.bind(this.device));

--- a/DysonLinkAccessory.js
+++ b/DysonLinkAccessory.js
@@ -78,7 +78,9 @@ class DysonLinkAccessory {
         // Updates the accessory information
         var accessoryInformationService = this.getService(Service.AccessoryInformation);
         accessoryInformationService.setCharacteristic(Characteristic.Manufacturer, "Dyson");
-        if (this.device.model == "438" || this.device.model == "520") {
+        if (this.device.model == "527") {
+            accessoryInformationService.setCharacteristic(Characteristic.Model, "Dyson Pure Hot + Cool " + this.device.model);
+        } else if (this.device.model == "438" || this.device.model == "520") {
             accessoryInformationService.setCharacteristic(Characteristic.Model, "Dyson Pure Cool " + this.device.model);
         } else {
             accessoryInformationService.setCharacteristic(Characteristic.Model, "Dyson " + this.device.model);

--- a/DysonLinkAccessory.js
+++ b/DysonLinkAccessory.js
@@ -64,7 +64,7 @@ class DysonLinkAccessory {
             .on("get", this.device.getAirQuality.bind(this.device));
 
 
-        if (this.device.model == "438" || this.device.model == "520") {
+        if (this.device.model == "438" || this.device.model == "520" || this.device.model == "527") {
             this.airSensor.getCharacteristic(Characteristic.PM2_5Density)
                 .on("get", this.device.getPM2_5Density.bind(this.device));
             this.airSensor.getCharacteristic(Characteristic.PM10Density)

--- a/DysonLinkAccessory.js
+++ b/DysonLinkAccessory.js
@@ -41,11 +41,16 @@ class DysonLinkAccessory {
 
     initSensor() {
         this.log("Init Sensor for " + this.displayName);
-        this.temperatureSensor = this.getService(Service.TemperatureSensor);
-        this.temperatureSensor
-            .getCharacteristic(Characteristic.CurrentTemperature)
-            .setProps({ minValue: -50, maxValue: 100, unit: "celsius" })
-            .on("get", this.device.getTemperture.bind(this.device));
+
+        if (this.device.model !== '527') {
+            // Don't add temperature sensor on HP04 since heater already acts as temperature sensor
+            // TODO: maybe we could do this to all devices that have heatAvailable?
+            this.temperatureSensor = this.getService(Service.TemperatureSensor);
+            this.temperatureSensor
+                .getCharacteristic(Characteristic.CurrentTemperature)
+                .setProps({minValue: -50, maxValue: 100, unit: "celsius"})
+                .on("get", this.device.getTemperture.bind(this.device));
+        }
 
         this.humiditySensor = this.getService(Service.HumiditySensor);
         this.humiditySensor

--- a/DysonLinkDevice.js
+++ b/DysonLinkDevice.js
@@ -152,9 +152,18 @@ class DysonLinkDevice {
     }
 
     setHeaterOn(value, callback) {
-        this.setState({ fmod: value==1 ? "FAN" : "OFF" });
-        if(value && this.fanState.heaterCoolerState == 2) {
+        if (this.model === '527') {
+            if (value == 1) {
+                this.setState({ hmod: "HEAT" });
+            } else {
+                this.setState({ fmod: "FAN" });
+                this.setState({ hmod: "OFF" });
+            }
+        } else {
+            this.setState({ fmod: value == 1 ? "FAN" : "OFF" });
+            if(value && this.fanState.heaterCoolerState == 2) {
 
+            }
         }
         this.isFanOn(callback);
     }

--- a/DysonLinkDevice.js
+++ b/DysonLinkDevice.js
@@ -479,8 +479,8 @@ class DysonLinkDevice {
     // 455 is Dyson Pure Hot + Cool Link, 527 is Dyson Pure Hot + Cool 2018
     get heatAvailable() { return this.model === "455" || this.model === "527"; }
 
-    // TP04 is 438, DP04 is 520
-    get Is2018Dyson() { return this.model === "438" || this.model === "520" ;}
+    // TP04 is 438, DP04 is 520, HP04 is 527
+    get Is2018Dyson() { return this.model === "438" || this.model === "520" || this.model === "527"; }
 
     get accessory() { return this._accessory ;}
     set accessory(acce) { this._accessory = acce; }

--- a/DysonLinkDevice.js
+++ b/DysonLinkDevice.js
@@ -470,7 +470,8 @@ class DysonLinkDevice {
     }
 
     get valid() { return this._valid; }
-    get heatAvailable() { return this.model === "455"; }
+    // 455 is Dyson Pure Hot + Cool Link, 527 is Dyson Pure Hot + Cool 2018
+    get heatAvailable() { return this.model === "455" || this.model === "527"; }
 
     // TP04 is 438, DP04 is 520
     get Is2018Dyson() { return this.model === "438" || this.model === "520" ;}

--- a/DysonLinkDevice.js
+++ b/DysonLinkDevice.js
@@ -178,7 +178,13 @@ class DysonLinkDevice {
     }
 
     setThresholdTemperture(value, callback) {
-        this.setState({hmax: (value + 273)*10 });
+        var kelvin = (value + 273) * 10;
+        if (this.model === '527') {
+            this.setState({hmax: kelvin.toString()});
+        } else {
+            this.setState({hmax: kelvin});
+        }
+
         this.getThresholdTemperture(callback);
 
     }


### PR DESCRIPTION
Adds support for Pure Hot + Cool 2018 device (HP04) which is the same as Pure Cool 2018 but has heating capability.

I also improved the heating behavior by removing AUTO and COOL states from heater cooler device, now the only options are HEAT or OFF. AUTO and COOL never worked correctly because the device does not support cooling and only showed "Cooling to (null)" in home app if any of these were selected. This change is only for HP04 model but it could be added for HP02 in the future?

I also removed the temperature sensor device on HP04 because the heater cooler device also acts as temperature sensor so there's no need to have two temperature sensors.

I've tested this on my TP04 and HP04 devices and it works fine. If someone with older devices like HP02, TP02 or DP02 could test this also, it would be great!