### PR TITLE
Fix the air quality when sensors are OFF

### DIFF
--- a/DysonEnvironmentState.js
+++ b/DysonEnvironmentState.js
@@ -14,12 +14,12 @@ class DysonEnvironmentState {
 
         // Gets the highest value, which means the one with the baddest results
         this._airQuality = Math.max(
-            this.getCharacteristicValue(newState.data.pm25), 
+            this.getCharacteristicValue(newState.data.pm25),
             this.getCharacteristicValue(newState.data.pm10),
             this.getCharacteristicValue(newState.data.va10),
             this.getCharacteristicValue(newState.data.noxl),
             p, v);
-        
+
         this._humidity = Number.parseInt(newState.data.hact);
         // Reference: http://aakira.hatenablog.com/entry/2016/08/12/012654
         this._temperature = Number.parseFloat(newState.data.tact) / 10 - 273;
@@ -40,6 +40,12 @@ class DysonEnvironmentState {
         if (!rawValue) {
             return 0;
         }
+
+       // If the sensor is OFF, 0 is returned.
+        if (rawValue == "OFF") {
+            return 0;
+        }
+
         let integerValue = Number.parseInt(rawValue);
 
         // Reduces the scale from 0-100 to 0-10 as used in the Dyson app

--- a/DysonLinkDevice.js
+++ b/DysonLinkDevice.js
@@ -85,7 +85,7 @@ class DysonLinkDevice {
 
 
     requestForCurrentUpdate() {
-        // Only do this when we have less than one listener to avoid multiple call 
+        // Only do this when we have less than one listener to avoid multiple call
         // OR when there are too many listeners (that might suggest that the previous calls were lost for some reason)
         let senorlistenerCount = this.environmentEvent.listenerCount(this.SENSOR_EVENT);
         let fanlistenerCount = this.mqttEvent.listenerCount(this.STATE_EVENT);
@@ -490,12 +490,12 @@ class DysonLinkDevice {
     }
 
     getTemperture(callback) {
-        
+
         this.log.debug(this.displayName + " Get temperture");
         if (this.notUpdatedRecently()) {
             if(this.mqttClient.connected){
                 this.environmentEvent.once(this.SENSOR_EVENT, () => {
-                    this.log.info(this.displayName + "- temperture new value: " + this.environment.temperature);
+                    this.log.info(this.displayName + " - Temperature new value: " + this.environment.temperature);
                     // Wait until the update and return
                     callback(null, this.environment.temperature);
                 });
@@ -507,7 +507,7 @@ class DysonLinkDevice {
             }
         }
         else {
-            this.log.info(this.displayName + "- temperture cached value: " + this.environment.temperature);
+            this.log.info(this.displayName + " - Temperature cached value: " + this.environment.temperature);
             callback(null, this.environment.temperature);
         }
     }
@@ -517,7 +517,7 @@ class DysonLinkDevice {
         if (this.notUpdatedRecently()) {
             if(this.mqttClient.connected){
                 this.environmentEvent.once(this.SENSOR_EVENT, () => {
-                    this.log.info(this.displayName + "- humidity new value: " + this.environment.humidity);
+                    this.log.info(this.displayName + " - Humidity new value: " + this.environment.humidity);
                     // Wait until the update and return
                     callback(null, this.environment.humidity);
                 });
@@ -529,7 +529,7 @@ class DysonLinkDevice {
             }
         }
         else {
-            this.log.info(this.displayName + "- humidity cached value: " + this.environment.humidity);
+            this.log.info(this.displayName + " - Humidity cached value: " + this.environment.humidity);
             callback(null, this.environment.humidity);
         }
     }
@@ -539,7 +539,7 @@ class DysonLinkDevice {
         if (this.notUpdatedRecently()) {
             if(this.mqttClient.connected){
                 this.environmentEvent.once(this.SENSOR_EVENT, () => {
-                    this.log.info(this.displayName + " - air quality new value: " + this.environment.airQuality);
+                    this.log.info(this.displayName + " - Air quality new value: " + this.environment.airQuality);
                     // Wait until the update and return
                     callback(null, this.environment.airQuality);
                 });
@@ -551,7 +551,7 @@ class DysonLinkDevice {
             }
         }
         else {
-            this.log.info(this.displayName + "- air quality cached value: " + this.environment.airQuality);
+            this.log.info(this.displayName + " - Air quality cached value: " + this.environment.airQuality);
             callback(null, this.environment.airQuality);
         }
     }


### PR DESCRIPTION
At the moment, when the sensors are OFF, the Air Quality is indicated to be bad in the Home App. That's because the input `OFF` returns `5` in this function: https://github.com/joe-ng/homebridge-dyson-link/blob/8dd0ff4fc1863685c253d174d5255c312f9d2a9d/DysonEnvironmentState.js#L37-L59

I added a clause to return `0` (the unknown value when `OFF` is supplied).

PS: Thank you for the great work with this package :)