### PR TITLE
Add a check to ignore output from sensors that are INIT'ing.

### DIFF
--- a/DysonEnvironmentState.js
+++ b/DysonEnvironmentState.js
@@ -46,6 +46,11 @@ class DysonEnvironmentState {
             return 0;
         }
 
+        // If the sensor is still being initialized, ignore it.
+        if (rawValue == "INIT") {
+            return 0;   
+        } 
+
         let integerValue = Number.parseInt(rawValue);
 
         // Reduces the scale from 0-100 to 0-10 as used in the Dyson app


### PR DESCRIPTION
After setting up my Dyson TP04, I noticed that my air quality was returning "Poor" in Home but "Good" in the Dyson app.

After a bit of googling, I determined that the problem is that a few sensors take time to boot up and return "INIT" while they're booting up. To prevent hitting the fallthrough case of "poor", I add an additional check to ignore those INIT values.

Tested in my local instance of homebridge, and it's working great!

Related issue: https://github.com/joe-ng/homebridge-dyson-link/issues/80